### PR TITLE
Fix 'Newer version' message when ahead of current commit.

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -35,7 +35,7 @@
                 You're running an unknown version of Mylar. <a href="update">Update</a> or 
                 <a href="#" onclick="$('#updatebar').slideUp('slow');">Close</a>
             </div>
-            % elif mylar.CURRENT_VERSION != mylar.LATEST_VERSION and mylar.INSTALL_TYPE != 'win':
+            % elif mylar.CURRENT_VERSION != mylar.LATEST_VERSION and mylar.INSTALL_TYPE != 'win' and mylar.COMMITS_BEHIND > 0:
             <div id="updatebar">
                 A <a href="http://github.com/evilhero/mylar/compare/${mylar.CURRENT_VERSION}...${mylar.LATEST_VERSION}"> newer version</a> is available. You're ${mylar.COMMITS_BEHIND} commits behind. <a href="update">Update</a> or <a href="#" onclick="$('#updatebar').slideUp('slow');">Close</a>
             </div>


### PR DESCRIPTION
The 'A newer version' message appears incorrectly when you're ahead of the current commit not behind it, albeit this is an unlikely issue as it'd only really happen when developing on the project, but it's an issue no less.
