### PR TITLE
Add sigterm handler to shutdown from rc.d scripts

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -17,6 +17,7 @@
 import os, sys, locale
 import time
 import threading
+import signal
 
 from lib.configobj import ConfigObj
 
@@ -28,7 +29,9 @@ try:
     import argparse
 except ImportError:
     import lib.argparse as argparse
-    
+
+def handler_sigterm(signum, frame):
+    mylar.SIGNAL = 'shutdown'
 
 def main():
 
@@ -173,6 +176,8 @@ def main():
         
     # Start the background threads
     mylar.start()
+
+    signal.signal(signal.SIGTERM, handler_sigterm)
     
     while True:
         if not mylar.SIGNAL:


### PR DESCRIPTION
rc.d scripts shut down Mylar daemon with SIGTERM which causes it to close without deleting the PID file (Issue #733). This installs a handler so the mylar daemon shuts down properly and doesn't need a manual deletion of the PID file.