### PR TITLE
Fix Mako Runtime Error when adding multiple comics.

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -43,8 +43,12 @@
                         </div>
                 </h1>
                              <div style="z-index:10; position: absolute; right: 0; top: 10;">
+                             % if 'Previous' in series:
                              <a href="comicDetails?ComicID=${series['Previous']}"><img src="interfaces/default/images/prev.gif" width="16" height="18" /></a>
+                             % endif
+                             % if 'Next' in series:
                              <a href="comicDetails?ComicID=${series['Next']}"><img src="interfaces/default/images/next.gif" width="16" height="18" /></a>
+                             % endif
                              </div>
 
 	</div>


### PR DESCRIPTION
Sometimes, when adding multiple comics, series['Previous'] or series['Next']
wouldn't be set by the time data/interfaces/default/comicdetails.html got
rendered, which resulted in a KeyError and a ugly error screen.