### PR TITLE
Replace 'trash' icons with more appropriate 'retry' icons for "loose …

### DIFF
--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -9,14 +9,14 @@
         <div id="subhead_container">
                 <div id="subhead_menu">
                     %if explicit == 'loose':
-                        <a id="menu_link_delete" title="This will search for ALL of the terms given : ${name}" href="searchit?name=${name |u}&explicit=loose">Search ALL terms</a>
-                        <a id="menu_link_delete" title="This will search EXPLICITLY for only the terms given : ${name}" href="searchit?name=${name |u}&explicit=explicit">Explicit Search</a>
+                        <a id="menu_link_retry" title="This will search for ALL of the terms given : ${name}" href="searchit?name=${name |u}&explicit=loose">Search ALL terms</a>
+                        <a id="menu_link_retry" title="This will search EXPLICITLY for only the terms given : ${name}" href="searchit?name=${name |u}&explicit=explicit">Explicit Search</a>
                     %elif explicit == 'explicit':
-                        <a id="menu_link_delete" title="Warning: This will search for ANY of the terms given : ${name} (this could take awhile)" href="searchit?name=${name |u}&explicit=loose">Loose Search</a>
-                        <a id="menu_link_delete" title="This will search for ALL of the terms given : ${name}" href="searchit?name=${name |u}&explicit=all">Search ALL terms</a>
+                        <a id="menu_link_retry" title="Warning: This will search for ANY of the terms given : ${name} (this could take awhile)" href="searchit?name=${name |u}&explicit=loose">Loose Search</a>
+                        <a id="menu_link_retry" title="This will search for ALL of the terms given : ${name}" href="searchit?name=${name |u}&explicit=all">Search ALL terms</a>
                     %elif explicit == 'all':
-                        <a id="menu_link_delete" title="This will search EXPLICITLY for only the terms given : ${name}" href="searchit?name=${name |u}&explicit=explicit">Explicit Search</a>
-                        <a id="menu_link_delete" title="Warning: This will search for ANY of the terms given : ${name} (this could take awhile)" href="searchit?name=${name |u}&explicit=loose">Loose Search</a>
+                        <a id="menu_link_retry" title="This will search EXPLICITLY for only the terms given : ${name}" href="searchit?name=${name |u}&explicit=explicit">Explicit Search</a>
+                        <a id="menu_link_retry" title="Warning: This will search for ANY of the terms given : ${name} (this could take awhile)" href="searchit?name=${name |u}&explicit=loose">Loose Search</a>
                     %endif
                 </div>
         </div>
@@ -112,7 +112,7 @@
         </script>
 
 	<script src="js/libs/jquery.dataTables.min.js"></script>
-	
+
 	<script>
         function initThisPage(){
 
@@ -122,7 +122,7 @@
 			       "bDestroy": true,
 			       "aoColumnDefs": [
 			         { 'bSortable': false, 'aTargets': [ 0,3 ] }
-			       ],	
+			       ],
 			       "oLanguage": {
 			     	       "sLengthMenu":"Show _MENU_ results per page",
 				       "sEmptyTable": "No results",

--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -8,13 +8,13 @@
 
 <%def name="headerIncludes()">
 	<div id="subhead_container">
-		<div id="subhead_menu">		
+		<div id="subhead_menu">
                         <a id="menu_link_refresh" href="manualpull">Refresh Pull-list</a>
-                        <a id="menu_link_delete" href="pullrecreate">Recreate Pull-list</a>
+                        <a id="menu_link_retry" href="pullrecreate">Recreate Pull-list</a>
                         <a id="menu_link_scan" class="button">Download</a>
                       <!--  <a id="menu_link_scan" onclick="doAjaxCall('MassWeeklyDownload?pulldate=${pulldate}, $(this)),'table'" href="#" data-success="Now Downloading Comics to : ${mylar.GRABBAG_DIR}">Download.</a> -->
 		</div>
-	</div>	
+	</div>
 	<a href="home" class="back">&laquo; Back to overview</a>
 </%def>
 
@@ -24,14 +24,14 @@
                    <h1>Weekly Pull list for : ${pulldate}</h1>
               %else:
                    <h1>Weekly Pull list for : ${pulldate} (${wantedcount})</h1>
-              %endif              
+              %endif
         </div>
 
         <div>
           <form action="MassWeeklyDownload" method="GET" id="MassDownload">
              <fieldset>
                   <div class="row">
-                       <input type="checkbox" name="weekfolder" id="weekfolder" value="1" ${checked(mylar.WEEKFOLDER)} /><label>Store in Weekly Directory</label> 
+                       <input type="checkbox" name="weekfolder" id="weekfolder" value="1" ${checked(mylar.WEEKFOLDER)} /><label>Store in Weekly Directory</label>
                        <small>Create ${weekfold}</small>
                  </div>
 
@@ -94,7 +94,7 @@
                                         %endif
                                         </td>
                                 %endif
-			</tr>			
+			</tr>
 		%endfor
 		</tbody>
 	</table>
@@ -112,7 +112,7 @@
             $('#MassDownload').submit();
             return true;
         });
-        </script>       	
+        </script>
 
 	<script>
 


### PR DESCRIPTION
…search", "explicit search", and "recreate pull-list"