### PR TITLE
remove width on h1 element for title

### DIFF
--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -862,7 +862,7 @@ div#searchbar .mini-icon {
 }
 #paddingheader h1 {
   line-height: 33px;
-  width: 450px;
+/* width: 450px; */
 }
 #paddingheader h1 img {
   float: left;

--- a/data/interfaces/default/css/style.less
+++ b/data/interfaces/default/css/style.less
@@ -532,7 +532,7 @@ div#searchbar {
     top: -25px;
     h1 {
         line-height: 33px;
-        width: 450px;
+//        width: 450px;
         img { 
         	float:left; 
         	margin-right: 5px;


### PR DESCRIPTION
It's presently set half as wide as the main div and makes titles wrap before they need to.

This makes the left-right arrows jump out from below your mouse.