### PR TITLE
rss search support for nzbhydra

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -361,7 +361,7 @@ def nzbs(provider=None, forcerss=False):
         newznabcat = newznabcat or '7030'
 
         # 11-21-2014: added &num=100 to return 100 results (or maximum) - unsure of cross-reliablity
-        _parse_feed(site, newznab_host[1].rstrip() + '/rss?t=' + str(newznabcat) + '&dl=1&i=' + str(newznabuid) + '&num=100&r=' + newznab_host[3].rstrip(), bool(newznab_host[2]))
+        _parse_feed(site, newznab_host[1].rstrip() + '/api?t=search&cat=' + str(newznabcat) + '&dl=1&i=' + str(newznabuid) + '&num=100&apikey=' + newznab_host[3].rstrip(), bool(newznab_host[2]))
 
     feeddata = []
 


### PR DESCRIPTION
This updates the search query for newznab indexers to a search rather than an RSS fetch. I think this is valid for all newznab hosts, but the goal is to fix NZBHydra, so a special case may be in order?

The changes are
- setting the search type to 'search' rather than the comic category (7030)
- setting the search category
- passing the api key as 'apikey', rather than 'r'