### PR TITLE
Compatibility with non-ASCII characters in filenames

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -341,7 +341,7 @@ class PostProcessor(object):
                 for fl in filelist['comiclist']:
                     if mylar.ENABLE_TORRENTS:
                         crcchk = None
-                        tcrc = helpers.crc(os.path.join(fl['comiclocation'], fl['comicfilename']))
+                        tcrc = helpers.crc(os.path.join(fl['comiclocation'], fl['comicfilename'].decode(mylar.SYS_ENCODING)))
                         crcchk = [x for x in pp_crclist if tcrc == x['crc']]
                         if crcchk:
                            logger.fdebug('Already post-processed this item %s - Ignoring' % crcchk)

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2273,7 +2273,7 @@ def crc(filename):
 
     #speed in lieu of memory (file into memory entirely)
     #return "%X" % (zlib.crc32(open(filename, "rb").read()) & 0xFFFFFFFF)
-
+    filename = filename.encode(mylar.SYS_ENCODING)
     return hashlib.md5(filename).hexdigest()
 
 def issue_find_ids(ComicName, ComicID, pack, IssueNumber):


### PR DESCRIPTION
When a filename has a non-ASCII character, like "ñ" o "Á", post-processing fails with encoding/decoding exceptions. This modifications fix this situation.
