### PR TITLE
Config module requires integer for log_level

### DIFF
--- a/mylar/logger.py
+++ b/mylar/logger.py
@@ -102,9 +102,9 @@ def initLogger(console=False, log_dir=False, init=False, verbose=False):
     if init is True:
         logger.setLevel(logging.DEBUG if verbose else logging.INFO)
     else:
-        if mylar.CONFIG.LOG_LEVEL == '1':
+        if mylar.CONFIG.LOG_LEVEL == 1:
             logger.setLevel(logging.DEBUG if verbose else logging.WARN)
-        elif mylar.CONFIG.LOG_LEVEL == '2':
+        elif mylar.CONFIG.LOG_LEVEL == 2:
             logger.setLevel(logging.DEBUG if verbose else logging.ERROR)
         else:
             logger.setLevel(logging.DEBUG if verbose else logging.INFO)


### PR DESCRIPTION
Noticed that the log_level was no longer working following the new config module

Looks like it was originally using `string` in the code, so this quick change will set it to the `int` that is required.