### PR TITLE
log a message when ComicVine has banned an IP adddress for exceeding the rate limit.

### DIFF
--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -74,7 +74,15 @@ def pullsearch(comicapi, comicquery, offset, type):
         logger.warn('Error fetching data from ComicVine: %s' % (e))
         return
 
-    dom = parseString(r.content) #(data)
+    try:
+        dom = parseString(r.content) #(data)
+    except Exception, e:
+        if u'<title>Abnormal Traffic Detected' in r.content:
+            logger.warn("Warning -- ComicVine has banned this server's IP address for exceeding the API rate limit.")
+        else:
+            logger.warn('While parsing data from ComicVine, got exception: %s for data: %s' % (str(e), r.content))
+        return None
+
     return dom
 
 def findComic(name, mode, issue, limityear=None, type=None):


### PR DESCRIPTION
When comicvine bans an IP for exceeding the rate limit, this prints a message in the log: 
"Warning -- ComicVine has banned this server's IP address for exceeding the API rate limit."

If the error is not due to an IP ban, it prints the exception message, and the content returned by the API.

It returns None, so that the UI shows no search result.