### PR TITLE
Fix so getComic empty results are consistent

### DIFF
--- a/mylar/api.py
+++ b/mylar/api.py
@@ -169,7 +169,7 @@ class Api(object):
         if mylar.CONFIG.ANNUALS_ON:
             annuals = self._dic_from_query('SELECT * FROM annuals WHERE ComicID="' + self.id + '"')
         else:
-            annuals = None
+            annuals = []
 
         self.data = {'comic': comic, 'issues': issues, 'annuals': annuals}
         return


### PR DESCRIPTION
The results returned from the api command to getComic would return empty dictionaries for comics and issues, but would return 'null' for annuals.  Now all of them return empty dictionaries when there aren't any results.