### PR TITLE
Starting mylar with --backup would cause an exception

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -194,7 +194,7 @@ def main():
                 back = os.path.join(backupdir, 'mylar.db')
                 back_1 = os.path.join(backupdir, 'mylar.db.1')
             else:
-                ogfile = config_file
+                ogfile = mylar.CONFIG_FILE
                 back = os.path.join(backupdir, 'config.ini')
                 back_1 = os.path.join(backupdir, 'config.ini.1')
 


### PR DESCRIPTION
I tried to start Mylar with the --backup switch, but it caused an unhandled exception.  So I updated Mylar.py to look for the config file from mylar.CONFIG_FILE, similar to the mylar.DB_FILE that is also backed up.

Result:  Starting Mylar with the --backup switch now copies the database and config files to the ./backup directory, as expected.  Renaming existing files if necessary.