### PR TITLE
fix typo

### DIFF
--- a/mylar/nzbget.py
+++ b/mylar/nzbget.py
@@ -78,7 +78,7 @@ class NZBGet(object):
         try:
             logger.fdebug('Now checking the active queue of nzbget for the download')
             queueinfo = self.server.listgroups()
-        except Expection as e:
+        except Exception as e:
             logger.warn('Error attempting to retrieve active queue listing: %s' % e)
             return {'status': False}
         else:


### PR DESCRIPTION
Traceback (most recent call last):
...
  File "/app/mylar/mylar/nzbget.py", line 81, in processor
    except Expection as e:
NameError: global name 'Expection' is not defined