### PR TITLE
add NZBID to "Could not find completed item" log message.

### DIFF
--- a/mylar/nzbget.py
+++ b/mylar/nzbget.py
@@ -144,5 +144,5 @@ class NZBGet(object):
                     logger.warn('no file found where it should be @ %s - is there another script that moves things after completion ?' % hq[0]['DestDir'])
                     return {'status': False}
         else:
-            logger.warn('Could not find completed item in history')
+            logger.warn('Could not find completed NZBID %s in history' % nzbid)
             return {'status': False}


### PR DESCRIPTION
Making this message more explicit may help less familiar users.