### PR TITLE
log an error message when ComicVine has banned mylar's IP adddress fo…

### DIFF
--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -77,7 +77,10 @@ def pullsearch(comicapi, comicquery, offset, type):
     try:
         dom = parseString(r.content) #(data)
     except ExpatError:
-        logger.warn('[WARNING] ComicVine is not responding correctly at the moment. This is usually due to some problems on their end. If you re-try things again in a few moments, it might work properly.')
+         if u'<title>Abnormal Traffic Detected' in r.content:
+            logger.error("ComicVine has banned this server's IP address because it exceeded the API rate limit.")
+        else:
+            logger.warn('[WARNING] ComicVine is not responding correctly at the moment. This is usually due to some problems on their end. If you re-try things again in a few moments, it might work properly.')
         return
 
     return dom
@@ -444,7 +447,14 @@ def storyarcinfo(xmlid):
 #        return
 #    arcdata = file.read()
 #    file.close()
-    arcdom = parseString(r.content) #(arcdata)
+    try:
+        arcdom = parseString(r.content) #(arcdata)
+    except ExpatError:
+        if u'<title>Abnormal Traffic Detected' in r.content:
+            logger.error("ComicVine has banned this server's IP address because it exceeded the API rate limit.")
+        else:
+            logger.warn('While parsing data from ComicVine, got exception: %s for data: %s' % (str(e), r.content))
+        return
 
     try:
         logger.fdebug('story_arc ascension')


### PR DESCRIPTION
…r exceeding the rate limit.

This logs an error message when ComicVine returns HTML with the tag <title>Abnormal Traffic Detected....

The ban typically lasts a couple of days, and this may at least save the user some time in recognizing that a ban is the issue.

This is only a suggestion.  Feel free to close this if it's not a preferred solution!