### PR TITLE
Change minimum cover JPG data size to 10,000 bytes (reduced from 30,000)

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3539,7 +3539,7 @@ def getImage(comicid, url, issueid=None):
         statinfo = os.stat(coverfile)
         coversize = statinfo.st_size
 
-    if int(coversize) < 30000 or str(r.status_code) != '200':
+    if int(coversize) < 10000 or str(r.status_code) != '200':
         if str(r.status_code) != '200':
             logger.info('Trying to grab an alternate cover due to problems trying to retrieve the main cover image.')
         else:


### PR DESCRIPTION
Covers for certain comics using 'poster effect' (no gradients) such as:
https://comicvine.gamespot.com/east-of-west/4050-59366/
have sizes of 26K for large, and 15K for small images.
This reduces the minimum cover JPG data size to 10K bytes.