### PR TITLE
Fix bug when removing parameters from filename with directory separators

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -557,6 +557,7 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
             #if comversion is None, remove it so it doesn't populate with 'None'
             if comversion == 'None':
                 chunk_f_f = re.sub('\$VolumeN', '', mylar.CONFIG.FILE_FORMAT)
+                chunk_f_f = chunk_f_f.strip().strip('\\').strip('/')
                 chunk_f = re.compile(r'\s+')
                 chunk_file_format = chunk_f.sub(' ', chunk_f_f)
                 logger.fdebug('No version # found for series, removing from filename')
@@ -566,6 +567,7 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
 
             if annualize is None:
                 chunk_f_f = re.sub('\$Annual', '', chunk_file_format)
+                chunk_f_f = chunk_f_f.strip().strip('\\').strip('/')
                 chunk_f = re.compile(r'\s+')
                 chunk_file_format = chunk_f.sub(' ', chunk_f_f)
                 logger.fdebug('not an annual - removing from filename paramaters')

--- a/mylar/moveit.py
+++ b/mylar/moveit.py
@@ -40,6 +40,13 @@ def movefiles(comicid, comlocation, imported):
                 logger.fdebug("Renaming files not enabled, keeping original filename(s)")
                 dstimp = os.path.join(comlocation, orig_filename)
 
+            if not os.path.exists(os.path.dirname(dstimp)):
+                logger.fdebug(os.path.dirname(dstimp) + ' does not exist - attempting to create...')
+                try:
+                    os.makedirs(os.path.dirname(dstimp), int(mylar.CONFIG.CHMOD_DIR))
+                except (OSError, IOError):
+                    logger.fdebug('Failed to create full directory path, but will try to move file anyway.')
+
             logger.info("moving " + srcimp + " ... to " + dstimp)
             try:
                 shutil.move(srcimp, dstimp)


### PR DESCRIPTION
If the user has directory separators in their filename parameters, stripping away unnecessary parameters may leave the filename with directory separators at the beginning. For example, "$VolumeN/$Series $Issue" would become "/$Series $Issue". The "os.path.join(comlocation, nfilename)" call in mylar/mylar/moveit.py:38 would then result in an absolute path of "/nfilename" instead of "comlocation/nfilename", placing the file at the filesystem root. Stripping away whitespace and forward/backslash directory separators lets the os.path.join() call maintain the proper path join.