### PR TITLE
Add issue name, number, and year to the Slack notification

### DIFF
--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -489,9 +489,9 @@ class SLACK:
         module += '[NOTIFIER]'
 
         if all([sent_to is not None, prov is not None]):
-            attachment_text += ' from %s and %s' % (prov, sent_to)
+            attachment_text += ' %s from %s and %s' % (snatched_nzb, prov, sent_to)
         elif sent_to is None:
-            attachment_text += ' from %s' % prov
+            attachment_text += ' %s from %s' % (snatched_nzb, prov)
         else:
             pass
 


### PR DESCRIPTION
Issue name and number used to be sent as variable snline. This was changed in search.py so this change just adds it back into the notification.