### PR TITLE
Reduced `getIndex` response on the API

### DIFF
--- a/mylar/api.py
+++ b/mylar/api.py
@@ -183,7 +183,18 @@ class Api(object):
                 self.data = self._error_with_message('Incorrect username or password.')
 
     def _getIndex(self, **kwargs):
-        self.data = self._dic_from_query('SELECT * from comics order by ComicSortName COLLATE NOCASE')
+        self.data = self._dic_from_query(
+            "SELECT ComicID as id,\
+                ComicName as name,\
+                ComicImageURL as imageURL,\
+                Status as status,\
+                ComicPublisher as publisher,\
+                ComicYear as year,\
+                LatestIssue as latestIssue,\
+                Total as totalIssues,\
+                DetailURL as detailsURL\
+            FROM comics \
+            ORDER BY ComicSortName COLLATE NOCASE")
         return
 
     def _getReadList(self, **kwargs):


### PR DESCRIPTION
**Reduced `getIndex` response data to only expose minimal and necessary data to the API.**

The current API `getIndex`response is exposing the full content of the comics table. That's not correct. Only part of the data should be exposed to the API so clients can consume it and display it.