### PR TITLE
Update mylar.initd

### DIFF
--- a/init-scripts/systemd/mylar.initd
+++ b/init-scripts/systemd/mylar.initd
@@ -1,4 +1,13 @@
 #!/usr/bin/env
+### BEGIN INIT INFO
+# Provides:          mylar
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Mylar
+### END INIT INFO
+
 # Script name
 NAME=mylar
 


### PR DESCRIPTION
Fix error "Default-Start contains no runlevels, aborting" on "sudo systemctl enable mylar".

I'm still unable to use systemd in Raspbian, when call "start", it goes on loop, without output.

Source: https://askubuntu.com/questions/909523/default-start-contains-no-runlevels-aborting