### PR TITLE
Minor fixes for search queue/post-processing locks

### DIFF
--- a/mylar/Failed.py
+++ b/mylar/Failed.py
@@ -170,15 +170,21 @@ class FailedProcessor(object):
                 sandwich = issueid
             elif 'G' in issueid or '-' in issueid:
                 sandwich = 1
-        if helpers.is_number(sandwich):
-            if sandwich < 900000:
+        try:
+            if helpers.is_number(sandwich):
+                if sandwich < 900000:
             # if sandwich is less than 900000 it's a normal watchlist download. Bypass.
-                pass
-        else:
-            logger.info('Failed download handling for story-arcs and one-off\'s are not supported yet. Be patient!')
-            self._log(' Unable to locate downloaded file to rename. PostProcessing aborted.')
+                    pass
+            else:
+                logger.info('Failed download handling for story-arcs and one-off\'s are not supported yet. Be patient!')
+                self._log(' Unable to locate downloaded file to rename. PostProcessing aborted.')
+                self.valreturn.append({"self.log": self.log,
+                                       "mode": 'stop'})
+                return self.queue.put(self.valreturn)
+        except NameError:
+            logger.info('sandwich was not defined. Post-processing aborted...')
             self.valreturn.append({"self.log": self.log,
-                                   "mode": 'stop'})
+                                       "mode": 'stop'})
 
             return self.queue.put(self.valreturn)
 

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -597,7 +597,7 @@ class FileChecker(object):
                 #now we try to find the series title &/or volume lablel.
                 if any( [sf.lower().startswith('v'), sf.lower().startswith('vol'), volumeprior == True, 'volume' in sf.lower(), 'vol' in sf.lower(), 'part' in sf.lower()] ) and sf.lower() not in {'one','two','three','four','five','six'}:
                     if any([ split_file[split_file.index(sf)].isdigit(), split_file[split_file.index(sf)][3:].isdigit(), split_file[split_file.index(sf)][1:].isdigit() ]):
-                        if '.' in sf:
+                        if all(identifier in sf for identifier in ['.', 'v']):
                             volume = sf.split('.')[0]
                         else:
                             volume = re.sub("[^0-9]", "", sf)

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -597,7 +597,10 @@ class FileChecker(object):
                 #now we try to find the series title &/or volume lablel.
                 if any( [sf.lower().startswith('v'), sf.lower().startswith('vol'), volumeprior == True, 'volume' in sf.lower(), 'vol' in sf.lower(), 'part' in sf.lower()] ) and sf.lower() not in {'one','two','three','four','five','six'}:
                     if any([ split_file[split_file.index(sf)].isdigit(), split_file[split_file.index(sf)][3:].isdigit(), split_file[split_file.index(sf)][1:].isdigit() ]):
-                        volume = re.sub("[^0-9]", "", sf)
+                        if '.' in sf:
+                            volume = sf.split('.')[0]
+                        else:
+                            volume = re.sub("[^0-9]", "", sf)
                         if volumeprior:
                             try:
                                 volume_found['position'] = split_file.index(volumeprior_label, current_pos -1) #if this passes, then we're ok, otherwise will try exception

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1529,7 +1529,12 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                 issinfo = mylar.COMICINFO['pack_issuelist']
             if issinfo is not None:
                 #we need to get EVERY issue ID within the pack and update the log to reflect that they're being downloaded via a pack.
-                logger.fdebug('Found matching comic within pack...preparing to send to Updater with IssueIDs: %s and nzbname of %s' % (issueid_info, nzbname))
+                
+                try:
+                    logger.fdebug('Found matching comic within pack...preparing to send to Updater with IssueIDs: %s and nzbname of %s' % (issueid_info, nzbname))
+                except NameError:
+                    logger.fdebug('Did not find issueid_info')
+                    
                 #because packs need to have every issue that's not already Downloaded in a Snatched status, throw it to the updater here as well.
                 for isid in issinfo['issues']:
                     updater.nzblog(isid['issueid'], nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, oneoff=oneoff)

--- a/post-processing/autoProcessComics.py
+++ b/post-processing/autoProcessComics.py
@@ -3,14 +3,26 @@ import os.path
 import ConfigParser
 import urllib2
 import urllib
+import platform
+
 try:
     import requests
     use_requests = True
 except ImportError:
-    print "Requests module not found on system. I'll revert so this will work, but you probably should install "
-    print "requests to bypass this in the future (ie. pip install requests)"
+    print '''Requests module not found on system. I'll revert so this will work, but you probably should install 
+        requests to bypass this in the future (i.e. pip install requests)'''
     use_requests = False
 
+if platform.system() == 'Windows':
+    try:
+        import win32api
+        use_win32api = True
+    except ImportError:
+        print '''The win32api module was not found on this system. While it's fine to run without it, you're 
+            running a Windows-based OS, so it would benefit you to install it. It enables ComicRN to better 
+            work with file paths beyond the 260 character limit. Run "pip install pypiwin32".'''
+    
+    
 apc_version = "2.04"
 
 def processEpisode(dirName, nzbName=None):
@@ -18,6 +30,8 @@ def processEpisode(dirName, nzbName=None):
     return processIssue(dirName, nzbName)
 
 def processIssue(dirName, nzbName=None, failed=False, comicrn_version=None):
+    if use_win32api is True:
+        dirName = win32api.GetShortPathName(dirName)
 
     config = ConfigParser.ConfigParser()
     configFilename = os.path.join(os.path.dirname(sys.argv[0]), "autoProcessComics.cfg")


### PR DESCRIPTION
242df9a - Windows has a 260 character limit on directory paths. The win32api module was installed and imported to allow for computers running Windows OS to bypass that limitation, as ComicRN was not able to move or rename files with a long file path.