### PR TITLE
Add imageurl for notifiers + Typo in log message

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -1942,8 +1942,12 @@ class PostProcessor(object):
                         logger.info('%s Post-Processing completed for: [ %s #%s ] %s' % (module, comicname, issuenumber, grab_dst))
                         self._log(u"Post Processing SUCCESSFUL! ")
 
+                    imageUrl = myDB.select('SELECT ImageURL from issues WHERE IssueID=?', [issueid])
+                    if imageUrl:
+                        imageUrl = imageUrl[0][0]
+                        
                     try:
-                        self.sendnotify(comicname, issueyear=None, issuenumOG=issuenumber, annchk=annchk, module=module)
+                        self.sendnotify(comicname, issueyear=None, issuenumOG=issuenumber, annchk=annchk, module=module, imageUrl=imageUrl)
                     except:
                         pass
 
@@ -2771,7 +2775,11 @@ class PostProcessor(object):
             #    self.sendnotify(series, issueyear, dispiss, annchk, module)
             #    return self.queue.put(self.valreturn)
 
-            self.sendnotify(series, issueyear, dispiss, annchk, module)
+            imageUrl = myDB.select('SELECT ImageURL from issues WHERE IssueID=?', [issueid])
+            if imageUrl:
+                imageUrl = imageUrl[0][0]
+                
+            self.sendnotify(series, issueyear, dispiss, annchk, module, imageUrl)
 
             logger.info('%s Post-Processing completed for: %s %s' % (module, series, dispiss))
             self._log(u"Post Processing SUCCESSFUL! ")
@@ -2784,7 +2792,7 @@ class PostProcessor(object):
             return self.queue.put(self.valreturn)
 
 
-    def sendnotify(self, series, issueyear, issuenumOG, annchk, module):
+    def sendnotify(self, series, issueyear, issuenumOG, annchk, module, imageUrl):
 
         if issueyear is None:
             prline = '%s %s' % (series, issuenumOG)
@@ -2812,7 +2820,7 @@ class PostProcessor(object):
 
         if mylar.CONFIG.TELEGRAM_ENABLED:
             telegram = notifiers.TELEGRAM()
-            telegram.notify(prline2)
+            telegram.notify(prline2, imageUrl)
 
         if mylar.CONFIG.SLACK_ENABLED:
             slack = notifiers.SLACK()

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -176,7 +176,7 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
         logger.info('Corrected year of ' + str(SeriesYear) + ' to corrected year for series that was manually entered previously of ' + str(csyear))
         SeriesYear = csyear
 
-    logger.info('Sucessfully retrieved details for ' + comic['ComicName'])
+    logger.info('Successfully retrieved details for ' + comic['ComicName'])
 
     #since the weekly issue check could return either annuals or issues, let's initialize it here so it carries through properly.
     weeklyissue_check = []

--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -340,25 +340,21 @@ class TELEGRAM:
         else:
             self.token = test_token
 
-    def notify(self, message, imageurl=None):
-        if imageurl:
+    def notify(self, message, imageUrl=None):
+        # Construct message
+        payload = {'chat_id': self.userid, 'text': message}
+        sendMethod = "sendMessage"
+        
+        if imageUrl:
             # Construct message
-            payload = {'chat_id': self.userid, 'caption': message, 'photo': imageurl} 
+            payload = {'chat_id': self.userid, 'caption': message, 'photo': imageUrl}
+            sendMethod = "sendPhoto"
 
-            # Send message to user using Telegram's Bot API
-            try:
-                response = requests.post(self.TELEGRAM_API % (self.token, "sendPhoto"), json=payload, verify=True)
-            except Exception, e:
-                logger.info(u'Telegram notify failed: ' + str(e))
-        else:
-            # Construct message
-            payload = {'chat_id': self.userid, 'text': message}
-
-            # Send message to user using Telegram's Bot API
-            try:
-                response = requests.post(self.TELEGRAM_API % (self.token, "sendMessage"), json=payload, verify=True)
-            except Exception, e:
-                logger.info(u'Telegram notify failed: ' + str(e))
+        # Send message to user using Telegram's Bot API
+        try:
+            response = requests.post(self.TELEGRAM_API % (self.token, sendMethod), json=payload, verify=True)
+        except Exception as e:
+            logger.info('Telegram notify failed: ' + str(e))
 
         # Error logging
         sent_successfuly = True

--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -357,13 +357,16 @@ class TELEGRAM:
             logger.info('Telegram notify failed: ' + str(e))
 
         # Error logging
-        sent_successfuly = True
+        sent_successfully = True
         if not response.status_code == 200:
             logger.info(u'Could not send notification to TelegramBot (token=%s). Response: [%s]' % (self.token, response.text))
-            sent_successfuly = False
+            sent_successfully = False
+            
+        if not sent_successfully and sendMethod != "sendMessage":
+            return self.notify(message)
 
         logger.info(u"Telegram notifications sent.")
-        return sent_successfuly
+        return sent_successfully
 
     def test_notify(self):
         return self.notify('Test Message: Release the Ninjas!')

--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -340,15 +340,25 @@ class TELEGRAM:
         else:
             self.token = test_token
 
-    def notify(self, message):
-        # Construct message
-        payload = {'chat_id': self.userid, 'text': message}
+    def notify(self, message, imageurl=None):
+        if imageurl:
+            # Construct message
+            payload = {'chat_id': self.userid, 'caption': message, 'photo': imageurl} 
 
-        # Send message to user using Telegram's Bot API
-        try:
-            response = requests.post(self.TELEGRAM_API % (self.token, "sendMessage"), json=payload, verify=True)
-        except Exception, e:
-            logger.info(u'Telegram notify failed: ' + str(e))
+            # Send message to user using Telegram's Bot API
+            try:
+                response = requests.post(self.TELEGRAM_API % (self.token, "sendPhoto"), json=payload, verify=True)
+            except Exception, e:
+                logger.info(u'Telegram notify failed: ' + str(e))
+        else:
+            # Construct message
+            payload = {'chat_id': self.userid, 'text': message}
+
+            # Send message to user using Telegram's Bot API
+            try:
+                response = requests.post(self.TELEGRAM_API % (self.token, "sendMessage"), json=payload, verify=True)
+            except Exception, e:
+                logger.info(u'Telegram notify failed: ' + str(e))
 
         # Error logging
         sent_successfuly = True


### PR DESCRIPTION
Small irrelevant fix of a typo in the log messages.

Would it be possible to add covers into Mylar? So when browsing the issues of a comic, you can see the cover of each issue in the list and when receiving notifications of processed issues, these cover can be sent as well?